### PR TITLE
Feat(Bot): Split plot and about menu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
             python -m pip install pytest
             python -m pytest
           fi
+
+      - name: Build release image
+        run: docker build --build-arg GAME_VERSION=v0.0.0 --tag trek-bot:test .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
 
     steps:
       - name: Check out release commit
@@ -54,3 +57,45 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
+
+  build-and-publish:
+    name: Build and publish ${{ needs.version.outputs.tag }}
+    needs: version
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_TAG: ${{ needs.version.outputs.tag }}
+      IMAGE: ghcr.io/simonborin/trek_bot
+
+    steps:
+      - name: Check out tagged revision
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish versioned image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}
+            ${{ env.IMAGE }}:latest
+          build-args: |
+            GAME_VERSION=${{ env.RELEASE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Create release tag
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-version
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: Create next SemVer tag
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out release commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Calculate release version
+        id: version
+        run: |
+          version="$(python scripts/next_version.py)"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+          echo "tag=v$version" >>"$GITHUB_OUTPUT"
+
+      - name: Push release tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            [[ "$(git rev-list -n 1 "$TAG")" == "$(git rev-parse HEAD)" ]]
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"

--- a/.testagent/plan.md
+++ b/.testagent/plan.md
@@ -16,5 +16,9 @@
    `test_game_metadata_derives_next_repository_version`.
 6. Cover automatic tagging after merge with
    `test_release_workflow_tags_merged_master_commits_automatically`.
-7. Run the narrow test target, review every assertion against the acceptance
+7. Cover GHCR and build/runtime version propagation with
+   `test_release_workflow_pushes_semver_and_latest_images_with_same_build_version`,
+   `test_dockerfile_promotes_build_version_to_runtime_environment`, and
+   `test_about_displays_same_v_prefixed_release_tag_from_environment`.
+8. Run the narrow test target, review every assertion against the acceptance
    checklist, and record the clean result in `.testagent/status.md`.

--- a/.testagent/plan.md
+++ b/.testagent/plan.md
@@ -9,6 +9,12 @@
    `test_about_callback_handler_is_registered`.
 4. Cover centralized metadata and About content with
    `test_about_text_uses_centralized_version_author_and_repository_metadata`.
-5. Run the narrow pytest target, review every assertion against the acceptance
+5. Cover automatic versioning with
+   `test_next_version_increments_latest_stable_v0_1_2_tag_to_0_1_3`,
+   `test_version_at_v0_1_2_tagged_head_reports_0_1_2`,
+   `test_game_metadata_has_no_hardcoded_0_1_0_version`, and
+   `test_game_metadata_derives_next_repository_version`.
+6. Cover automatic tagging after merge with
+   `test_release_workflow_tags_merged_master_commits_automatically`.
+7. Run the narrow test target, review every assertion against the acceptance
    checklist, and record the clean result in `.testagent/status.md`.
-

--- a/.testagent/plan.md
+++ b/.testagent/plan.md
@@ -1,0 +1,14 @@
+# Plan
+
+1. Add an AST helper that reads assignments, function calls, and handler
+   registrations without importing application modules.
+2. Cover menu requirements with
+   `test_main_menu_exposes_plot_and_about_actions`.
+3. Cover handler registration with
+   `test_plot_callback_handler_is_registered` and
+   `test_about_callback_handler_is_registered`.
+4. Cover centralized metadata and About content with
+   `test_about_text_uses_centralized_version_author_and_repository_metadata`.
+5. Run the narrow pytest target, review every assertion against the acceptance
+   checklist, and record the clean result in `.testagent/status.md`.
+

--- a/.testagent/research.md
+++ b/.testagent/research.md
@@ -10,7 +10,9 @@
 - `scripts/next_version.py`: resolves a release tag at `HEAD`, or increments the
   latest stable SemVer tag for an unreleased commit.
 - `.github/workflows/release.yml`: automatically tags commits merged into
-  `master`.
+  `master`, then builds and pushes immutable and rolling GHCR image tags.
+- `Dockerfile`: promotes the release build argument into the runtime
+  `GAME_VERSION` environment variable consumed by About.
 - `tests/test_menu_about.py`: source-based tests added for this request.
 - `tests/test_release_version.py`: isolated Git/CLI and workflow contract tests.
 
@@ -31,10 +33,19 @@
 - [x] About content is centralized outside `trek.py`.
 - [x] `game_metadata.py` has no hardcoded `0.1.0`.
 - [x] `GAME_VERSION` honors the environment override.
-- [x] With latest stable tag `v0.1.2`, an unreleased commit resolves to `0.1.3`.
+- [x] With latest stable tag `v0.1.2`, the version script calculates `0.1.3`
+  and About exposes the corresponding release tag `v0.1.3`.
 - [x] At a `HEAD` tagged `v0.1.2`, the current release remains `0.1.2`.
 - [x] About content displays the centralized automatic version.
+- [x] About displays the same `vX.Y.Z` release tag supplied by the image.
 - [x] About content exposes author `Simon Borin (@blooomberg)`.
 - [x] About content exposes `https://github.com/SimonBorin/trek_bot`.
 - [x] Release workflow automatically tags merged `master` commits.
+- [x] Release workflow pushes
+  `ghcr.io/simonborin/trek_bot:vX.Y.Z` and
+  `ghcr.io/simonborin/trek_bot:latest`.
+- [x] The exact same `RELEASE_TAG`, including `v`, is passed as Docker build
+  argument `GAME_VERSION`.
+- [x] Dockerfile exposes build argument `GAME_VERSION` as runtime environment
+  variable `GAME_VERSION`.
 - [x] Tests do not import or run Telegram or MongoDB.

--- a/.testagent/research.md
+++ b/.testagent/research.md
@@ -7,7 +7,12 @@
   module scope. Importing it would initialize Telegram and MongoDB clients.
 - `game_metadata.py`: central source for the game version, author, repository,
   and composed About text.
+- `scripts/next_version.py`: resolves a release tag at `HEAD`, or increments the
+  latest stable SemVer tag for an unreleased commit.
+- `.github/workflows/release.yml`: automatically tags commits merged into
+  `master`.
 - `tests/test_menu_about.py`: source-based tests added for this request.
+- `tests/test_release_version.py`: isolated Git/CLI and workflow contract tests.
 
 ## Existing conventions
 
@@ -24,7 +29,12 @@
 - [x] A callback handler registers `plot` for the Plot callback.
 - [x] A callback handler registers `about` for the About callback.
 - [x] About content is centralized outside `trek.py`.
-- [x] Centralized game version is `0.1.0`.
+- [x] `game_metadata.py` has no hardcoded `0.1.0`.
+- [x] `GAME_VERSION` honors the environment override.
+- [x] With latest stable tag `v0.1.2`, an unreleased commit resolves to `0.1.3`.
+- [x] At a `HEAD` tagged `v0.1.2`, the current release remains `0.1.2`.
+- [x] About content displays the centralized automatic version.
 - [x] About content exposes author `Simon Borin (@blooomberg)`.
 - [x] About content exposes `https://github.com/SimonBorin/trek_bot`.
+- [x] Release workflow automatically tags merged `master` commits.
 - [x] Tests do not import or run Telegram or MongoDB.

--- a/.testagent/research.md
+++ b/.testagent/research.md
@@ -1,0 +1,30 @@
+# Research
+
+## Bounded target inventory
+
+- `keyboards.py`: `menu_keyboard()` declares the main menu buttons.
+- `trek.py`: declares `plot()` and `about()` and registers callback handlers at
+  module scope. Importing it would initialize Telegram and MongoDB clients.
+- `game_metadata.py`: central source for the game version, author, repository,
+  and composed About text.
+- `tests/test_menu_about.py`: source-based tests added for this request.
+
+## Existing conventions
+
+- The repository previously had no test directory, pytest configuration, or
+  representative tests.
+- Runtime dependencies are listed in a plain `requirements` file.
+- Tests therefore use pytest's built-in assertion style and Python's `ast`
+  module, with no Telegram, MongoDB, environment, or network dependency.
+
+## Acceptance checklist
+
+- [x] Main menu has `Plot` with callback data `plot`.
+- [x] Main menu has `About` with callback data `about`.
+- [x] A callback handler registers `plot` for the Plot callback.
+- [x] A callback handler registers `about` for the About callback.
+- [x] About content is centralized outside `trek.py`.
+- [x] Centralized game version is `0.1.0`.
+- [x] About content exposes author `Simon Borin (@blooomberg)`.
+- [x] About content exposes `https://github.com/SimonBorin/trek_bot`.
+- [x] Tests do not import or run Telegram or MongoDB.

--- a/.testagent/status.md
+++ b/.testagent/status.md
@@ -2,15 +2,18 @@
 
 - Research: complete.
 - Plan: complete.
-- Implementation: complete (`tests/test_menu_about.py`, four AST/source-based
-  regression tests).
-- Validation: complete. `python3 -m unittest discover -s tests -p
-  'test_*.py' -v` passed 4 tests.
+- Implementation: complete (`tests/test_menu_about.py` and
+  `tests/test_release_version.py`, nine isolated regression tests).
+- Validation: complete. `python3 -m unittest discover -s tests -v` passed all
+  9 tests; `git diff --check` passed.
 - Gap review: complete. Each requested menu action, handler registration, and
-  About metadata field maps to an explicit assertion. The About handler is also
-  verified to consume the centralized `ABOUT_TEXT`.
+  About metadata field maps to an explicit assertion. Automatic SemVer covers
+  a real temporary Git repository both at tagged `HEAD` (`0.1.2`) and after a
+  later commit (`0.1.3`). The workflow assertions cover the merged-PR trigger,
+  `master`, full tag history, calculation, tag creation, and tag push.
 - Assertion review: complete. Handler patterns are executed with
-  `re.fullmatch`; menu labels and callback data are asserted as pairs; metadata
-  values and rendered About lines are both asserted.
+  `re.fullmatch`; menu labels and callback data are asserted as pairs;
+  environment-derived and repository-derived versions are asserted separately;
+  the old hardcoded version is explicitly rejected.
 - Runtime isolation: confirmed. Tests parse source with `ast` and never import
   `trek`, Telegram, or MongoDB.

--- a/.testagent/status.md
+++ b/.testagent/status.md
@@ -3,17 +3,21 @@
 - Research: complete.
 - Plan: complete.
 - Implementation: complete (`tests/test_menu_about.py` and
-  `tests/test_release_version.py`, nine isolated regression tests).
+  `tests/test_release_version.py`, twelve isolated regression tests).
 - Validation: complete. `python3 -m unittest discover -s tests -v` passed all
-  9 tests; `git diff --check` passed.
+  12 tests; `git diff --check` passed.
 - Gap review: complete. Each requested menu action, handler registration, and
   About metadata field maps to an explicit assertion. Automatic SemVer covers
   a real temporary Git repository both at tagged `HEAD` (`0.1.2`) and after a
   later commit (`0.1.3`). The workflow assertions cover the merged-PR trigger,
-  `master`, full tag history, calculation, tag creation, and tag push.
+  `master`, full tag history, calculation, tag creation, tag push, exact
+  immutable and `latest` GHCR tags, the `version.outputs.tag` →
+  `needs.version.outputs.tag` dependency chain, and build/runtime version
+  propagation.
 - Assertion review: complete. Handler patterns are executed with
   `re.fullmatch`; menu labels and callback data are asserted as pairs;
   environment-derived and repository-derived versions are asserted separately;
-  the old hardcoded version is explicitly rejected.
+  the old hardcoded version is explicitly rejected; the image and About
+  assertions retain the `v` prefix.
 - Runtime isolation: confirmed. Tests parse source with `ast` and never import
   `trek`, Telegram, or MongoDB.

--- a/.testagent/status.md
+++ b/.testagent/status.md
@@ -1,0 +1,16 @@
+# Status
+
+- Research: complete.
+- Plan: complete.
+- Implementation: complete (`tests/test_menu_about.py`, four AST/source-based
+  regression tests).
+- Validation: complete. `python3 -m unittest discover -s tests -p
+  'test_*.py' -v` passed 4 tests.
+- Gap review: complete. Each requested menu action, handler registration, and
+  About metadata field maps to an explicit assertion. The About handler is also
+  verified to consume the centralized `ABOUT_TEXT`.
+- Assertion review: complete. Handler patterns are executed with
+  `re.fullmatch`; menu labels and callback data are asserted as pairs; metadata
+  values and rendered About lines are both asserted.
+- Runtime isolation: confirmed. Tests parse source with `ast` and never import
+  `trek`, Telegram, or MongoDB.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM python:3.6
+FROM python:3.11-slim
+
+ARG GAME_VERSION=development
+
 LABEL maintainer="Semen Borin <mrblooomberg@gmail.com>"
-ENV PYTHONUNBUFFERED 0
-RUN apt-get update -y &&\
-    apt-get install -y tzdata \
- && cp /usr/share/zoneinfo/Europe/Moscow /etc/localtime
+LABEL org.opencontainers.image.source="https://github.com/SimonBorin/trek_bot"
+LABEL org.opencontainers.image.version="$GAME_VERSION"
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV GAME_VERSION="$GAME_VERSION"
+
 COPY ./requirements /trek/requirements
 WORKDIR /trek
-RUN pip install -r requirements
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir -r requirements
 COPY ./ /trek
-ENTRYPOINT [ "python" ]
-CMD [ "trek.py" ]
+
+CMD ["python", "trek.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@ version: "3"
 services:
 
     StarTrek:
-        image: blooomberg/trek_bot
+        image: ghcr.io/simonborin/trek_bot:${GAME_VERSION:-latest}
         build:
             context: .
             dockerfile: ./Dockerfile
+            args:
+                GAME_VERSION: ${GAME_VERSION:-development}
         links:
             - mongo
         restart: always
@@ -16,4 +18,3 @@ services:
         restart: always
         ports:
             - 27017:27017
-

--- a/game_metadata.py
+++ b/game_metadata.py
@@ -1,5 +1,10 @@
+import os
+
+from scripts.next_version import repository_version
+
+
 GAME_TITLE = "Star Trek Text Game Bot"
-GAME_VERSION = "0.1.0"
+GAME_VERSION = os.environ.get("GAME_VERSION") or repository_version()
 AUTHOR_NAME = "Simon Borin"
 AUTHOR_HANDLE = "@blooomberg"
 REPOSITORY_URL = "https://github.com/SimonBorin/trek_bot"

--- a/game_metadata.py
+++ b/game_metadata.py
@@ -4,7 +4,7 @@ from scripts.next_version import repository_version
 
 
 GAME_TITLE = "Star Trek Text Game Bot"
-GAME_VERSION = os.environ.get("GAME_VERSION") or repository_version()
+GAME_VERSION = os.environ.get("GAME_VERSION") or f"v{repository_version()}"
 AUTHOR_NAME = "Simon Borin"
 AUTHOR_HANDLE = "@blooomberg"
 REPOSITORY_URL = "https://github.com/SimonBorin/trek_bot"

--- a/game_metadata.py
+++ b/game_metadata.py
@@ -1,0 +1,12 @@
+GAME_TITLE = "Star Trek Text Game Bot"
+GAME_VERSION = "0.1.0"
+AUTHOR_NAME = "Simon Borin"
+AUTHOR_HANDLE = "@blooomberg"
+REPOSITORY_URL = "https://github.com/SimonBorin/trek_bot"
+
+ABOUT_TEXT = (
+    f"{GAME_TITLE}\n"
+    f"Version: {GAME_VERSION}\n"
+    f"Author: {AUTHOR_NAME} ({AUTHOR_HANDLE})\n"
+    f"GitHub: {REPOSITORY_URL}"
+)

--- a/keyboards.py
+++ b/keyboards.py
@@ -67,7 +67,8 @@ def menu_keyboard():
     keyboard = [
         [InlineKeyboardButton('Restart', callback_data='restart')],
         [InlineKeyboardButton('Manual', callback_data='manual')],
-        [InlineKeyboardButton('Info', callback_data='info')],
+        [InlineKeyboardButton('Plot', callback_data='plot')],
+        [InlineKeyboardButton('About', callback_data='about')],
         [InlineKeyboardButton('Back', callback_data='back2main')]
     ]
     return InlineKeyboardMarkup(keyboard)

--- a/scripts/next_version.py
+++ b/scripts/next_version.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Resolve the current release or calculate the next patch SemVer."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Iterable
+
+SEMVER_PATTERN = re.compile(r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def parse_version(value: str) -> tuple[int, int, int] | None:
+    match = SEMVER_PATTERN.fullmatch(value.strip())
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def latest_version(tags: Iterable[str]) -> tuple[int, int, int] | None:
+    versions = (version for tag in tags if (version := parse_version(tag)) is not None)
+    return max(versions, default=None)
+
+
+def format_version(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def next_version(tags: Iterable[str]) -> str:
+    current = latest_version(tags)
+    if current is None:
+        raise RuntimeError("A stable SemVer tag is required to calculate the next version")
+    major, minor, patch = current
+    return format_version((major, minor, patch + 1))
+
+
+def git_tags(*arguments: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "tag", *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.splitlines()
+
+
+def repository_version() -> str:
+    current = latest_version(git_tags("--points-at", "HEAD"))
+    if current is not None:
+        return format_version(current)
+    return next_version(git_tags("--list"))
+
+
+def main() -> int:
+    print(repository_version())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_menu_about.py
+++ b/tests/test_menu_about.py
@@ -115,7 +115,7 @@ class MenuAboutTests(unittest.TestCase):
     def test_about_text_uses_centralized_version_author_and_repository_metadata(self):
         trek = parse_module("trek.py")
         about = function_node(trek, "about")
-        metadata = metadata_values("9.8.7")
+        metadata = metadata_values("v9.8.7")
         imports = {
             alias.name
             for node in trek.body
@@ -130,13 +130,19 @@ class MenuAboutTests(unittest.TestCase):
                 for node in ast.walk(about)
             )
         )
-        self.assertEqual(metadata["version"], "9.8.7")
-        self.assertIn("Version: 9.8.7", metadata["about"])
+        self.assertEqual(metadata["version"], "v9.8.7")
+        self.assertIn("Version: v9.8.7", metadata["about"])
         self.assertIn("Author: Simon Borin (@blooomberg)", metadata["about"])
         self.assertIn(
             "GitHub: https://github.com/SimonBorin/trek_bot",
             metadata["about"],
         )
+
+    def test_about_displays_same_v_prefixed_release_tag_from_environment(self):
+        metadata = metadata_values("v1.2.3")
+
+        self.assertEqual(metadata["version"], "v1.2.3")
+        self.assertIn("Version: v1.2.3", metadata["about"])
 
     def test_game_metadata_has_no_hardcoded_0_1_0_version(self):
         metadata_source = (ROOT / "game_metadata.py").read_text(encoding="utf-8")
@@ -145,4 +151,4 @@ class MenuAboutTests(unittest.TestCase):
         self.assertNotIn("'0.1.0'", metadata_source)
 
     def test_game_metadata_derives_next_repository_version(self):
-        self.assertEqual(metadata_values()["version"], "0.1.3")
+        self.assertEqual(metadata_values()["version"], "v0.1.3")

--- a/tests/test_menu_about.py
+++ b/tests/test_menu_about.py
@@ -1,0 +1,127 @@
+import ast
+from pathlib import Path
+import re
+import unittest
+import warnings
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def parse_module(filename):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SyntaxWarning)
+        return ast.parse((ROOT / filename).read_text(encoding="utf-8"))
+
+
+def function_node(module, name):
+    return next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def callback_buttons(function):
+    return {
+        (call.args[0].value, keyword.value.value)
+        for call in ast.walk(function)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Name)
+        and call.func.id == "InlineKeyboardButton"
+        and call.args
+        and isinstance(call.args[0], ast.Constant)
+        for keyword in call.keywords
+        if keyword.arg == "callback_data"
+        and isinstance(keyword.value, ast.Constant)
+    }
+
+
+def callback_handler_patterns(module):
+    handlers = {}
+    for call in ast.walk(module):
+        if (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "CallbackQueryHandler"
+            and call.args
+            and isinstance(call.args[0], ast.Name)
+        ):
+            patterns = [
+                keyword.value.value
+                for keyword in call.keywords
+                if keyword.arg == "pattern"
+                and isinstance(keyword.value, ast.Constant)
+            ]
+            handlers[call.args[0].id] = patterns
+    return handlers
+
+
+def assigned_string_values(module):
+    namespace = {}
+    for node in module.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            try:
+                namespace[node.targets[0].id] = eval(
+                    compile(ast.Expression(node.value), "<metadata>", "eval"),
+                    {"__builtins__": {}},
+                    namespace,
+                )
+            except (NameError, TypeError):
+                continue
+    return namespace
+
+
+class MenuAboutTests(unittest.TestCase):
+    def test_main_menu_exposes_plot_and_about_actions(self):
+        menu = function_node(parse_module("keyboards.py"), "menu_keyboard")
+
+        self.assertIn(("Plot", "plot"), callback_buttons(menu))
+        self.assertIn(("About", "about"), callback_buttons(menu))
+        self.assertNotIn(("Info", "info"), callback_buttons(menu))
+
+    def test_plot_callback_handler_is_registered(self):
+        handlers = callback_handler_patterns(parse_module("trek.py"))
+
+        self.assertIn("plot", handlers)
+        self.assertTrue(
+            any(re.fullmatch(pattern, "plot") for pattern in handlers["plot"])
+        )
+
+    def test_about_callback_handler_is_registered(self):
+        handlers = callback_handler_patterns(parse_module("trek.py"))
+
+        self.assertIn("about", handlers)
+        self.assertTrue(
+            any(re.fullmatch(pattern, "about") for pattern in handlers["about"])
+        )
+
+    def test_about_text_uses_centralized_version_author_and_repository_metadata(self):
+        trek = parse_module("trek.py")
+        about = function_node(trek, "about")
+        metadata = assigned_string_values(parse_module("game_metadata.py"))
+        imports = {
+            alias.name
+            for node in trek.body
+            if isinstance(node, ast.ImportFrom) and node.module == "game_metadata"
+            for alias in node.names
+        }
+
+        self.assertIn("ABOUT_TEXT", imports)
+        self.assertTrue(
+            any(
+                isinstance(node, ast.Name) and node.id == "ABOUT_TEXT"
+                for node in ast.walk(about)
+            )
+        )
+        self.assertEqual(metadata["GAME_VERSION"], "0.1.0")
+        self.assertIn("Version: 0.1.0", metadata["ABOUT_TEXT"])
+        self.assertIn("Author: Simon Borin (@blooomberg)", metadata["ABOUT_TEXT"])
+        self.assertIn(
+            "GitHub: https://github.com/SimonBorin/trek_bot",
+            metadata["ABOUT_TEXT"],
+        )

--- a/tests/test_menu_about.py
+++ b/tests/test_menu_about.py
@@ -1,6 +1,10 @@
 import ast
+import json
+import os
 from pathlib import Path
 import re
+import subprocess
+import sys
 import unittest
 import warnings
 
@@ -57,23 +61,31 @@ def callback_handler_patterns(module):
     return handlers
 
 
-def assigned_string_values(module):
-    namespace = {}
-    for node in module.body:
-        if (
-            isinstance(node, ast.Assign)
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Name)
-        ):
-            try:
-                namespace[node.targets[0].id] = eval(
-                    compile(ast.Expression(node.value), "<metadata>", "eval"),
-                    {"__builtins__": {}},
-                    namespace,
-                )
-            except (NameError, TypeError):
-                continue
-    return namespace
+def metadata_values(version=None):
+    environment = os.environ.copy()
+    if version is None:
+        environment.pop("GAME_VERSION", None)
+    else:
+        environment["GAME_VERSION"] = version
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, game_metadata; "
+                "print(json.dumps({"
+                "'version': game_metadata.GAME_VERSION, "
+                "'about': game_metadata.ABOUT_TEXT"
+                "}))"
+            ),
+        ],
+        cwd=ROOT,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
 
 
 class MenuAboutTests(unittest.TestCase):
@@ -103,7 +115,7 @@ class MenuAboutTests(unittest.TestCase):
     def test_about_text_uses_centralized_version_author_and_repository_metadata(self):
         trek = parse_module("trek.py")
         about = function_node(trek, "about")
-        metadata = assigned_string_values(parse_module("game_metadata.py"))
+        metadata = metadata_values("9.8.7")
         imports = {
             alias.name
             for node in trek.body
@@ -118,10 +130,19 @@ class MenuAboutTests(unittest.TestCase):
                 for node in ast.walk(about)
             )
         )
-        self.assertEqual(metadata["GAME_VERSION"], "0.1.0")
-        self.assertIn("Version: 0.1.0", metadata["ABOUT_TEXT"])
-        self.assertIn("Author: Simon Borin (@blooomberg)", metadata["ABOUT_TEXT"])
+        self.assertEqual(metadata["version"], "9.8.7")
+        self.assertIn("Version: 9.8.7", metadata["about"])
+        self.assertIn("Author: Simon Borin (@blooomberg)", metadata["about"])
         self.assertIn(
             "GitHub: https://github.com/SimonBorin/trek_bot",
-            metadata["ABOUT_TEXT"],
+            metadata["about"],
         )
+
+    def test_game_metadata_has_no_hardcoded_0_1_0_version(self):
+        metadata_source = (ROOT / "game_metadata.py").read_text(encoding="utf-8")
+
+        self.assertNotIn('"0.1.0"', metadata_source)
+        self.assertNotIn("'0.1.0'", metadata_source)
+
+    def test_game_metadata_derives_next_repository_version(self):
+        self.assertEqual(metadata_values()["version"], "0.1.3")

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -81,3 +81,41 @@ class ReleaseVersionTests(unittest.TestCase):
         self.assertIn("python scripts/next_version.py", workflow)
         self.assertIn('git tag -a "$TAG"', workflow)
         self.assertIn('git push origin "$TAG"', workflow)
+
+    def test_release_workflow_pushes_semver_and_latest_images_with_same_build_version(
+        self,
+    ):
+        workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("tag: ${{ steps.version.outputs.tag }}", workflow)
+        self.assertRegex(workflow, r"(?m)^\s+needs:\s+version\s*$")
+        self.assertIn(
+            "RELEASE_TAG: ${{ needs.version.outputs.tag }}",
+            workflow,
+        )
+        self.assertIn(
+            "GAME_VERSION=${{ env.RELEASE_TAG }}",
+            workflow,
+        )
+        self.assertIn("IMAGE: ghcr.io/simonborin/trek_bot", workflow)
+        self.assertIn("${{ env.IMAGE }}:${{ env.RELEASE_TAG }}", workflow)
+        self.assertIn("${{ env.IMAGE }}:latest", workflow)
+        self.assertIn("ref: ${{ env.RELEASE_TAG }}", workflow)
+        self.assertRegex(workflow, r"(?m)^\s+push:\s+true\s*$")
+
+    def test_dockerfile_promotes_build_version_to_runtime_environment(self):
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+        self.assertRegex(
+            dockerfile,
+            r"(?m)^ARG GAME_VERSION(?:=[^\s]+)?\s*$",
+        )
+        self.assertRegex(
+            dockerfile,
+            (
+                r"(?m)^ENV GAME_VERSION="
+                r"[\"']?(?:\$\{GAME_VERSION\}|\$GAME_VERSION)[\"']?\s*$"
+            ),
+        )

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NEXT_VERSION_SCRIPT = ROOT / "scripts" / "next_version.py"
+
+
+def git(repo, *arguments):
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class ReleaseVersionTests(unittest.TestCase):
+    def test_version_at_v0_1_2_tagged_head_reports_0_1_2(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            git(repo, "init", "--quiet")
+            git(repo, "config", "user.name", "Test User")
+            git(repo, "config", "user.email", "test@example.com")
+            marker = repo / "marker"
+            marker.write_text("release\n", encoding="utf-8")
+            git(repo, "add", "marker")
+            git(repo, "commit", "--quiet", "-m", "Release")
+            git(repo, "tag", "v0.1.2")
+
+            result = subprocess.run(
+                [sys.executable, NEXT_VERSION_SCRIPT],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.stdout.strip(), "0.1.2")
+
+    def test_next_version_increments_latest_stable_v0_1_2_tag_to_0_1_3(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            git(repo, "init", "--quiet")
+            git(repo, "config", "user.name", "Test User")
+            git(repo, "config", "user.email", "test@example.com")
+            marker = repo / "marker"
+            marker.write_text("release\n", encoding="utf-8")
+            git(repo, "add", "marker")
+            git(repo, "commit", "--quiet", "-m", "Release")
+            git(repo, "tag", "v0.1.2")
+            git(repo, "tag", "v9.9.9-rc1")
+            marker.write_text("next\n", encoding="utf-8")
+            git(repo, "commit", "--quiet", "-am", "Next")
+
+            result = subprocess.run(
+                [sys.executable, NEXT_VERSION_SCRIPT],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.stdout.strip(), "0.1.3")
+
+    def test_release_workflow_tags_merged_master_commits_automatically(self):
+        workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertRegex(
+            workflow,
+            r"(?ms)^on:\s*\n\s+pull_request:\s*\n\s+branches:\s*\n\s+- master",
+        )
+        self.assertIn("github.event.pull_request.merged == true", workflow)
+        self.assertIn("fetch-depth: 0", workflow)
+        self.assertIn("python scripts/next_version.py", workflow)
+        self.assertIn('git tag -a "$TAG"', workflow)
+        self.assertIn('git push origin "$TAG"', workflow)

--- a/trek.py
+++ b/trek.py
@@ -7,6 +7,7 @@ from telegram.ext import CommandHandler, CallbackQueryHandler
 import telegram
 from pymongo import MongoClient
 from keyboards import main_keyboard, num_keyboard, menu_keyboard, manual_keyboard, restart_keyboard, helm_keyboard
+from game_metadata import ABOUT_TEXT
 
 # with open(r'./params.yaml') as file:
 #     props = yaml.load(file, Loader=yaml.FullLoader)
@@ -23,13 +24,22 @@ parameters_db = db.parameters
 sub_param_db = db.sub_param
 
 
-def info(update, context):
-    info_msg = 'Thats my boring bot, based on star trek text rpg from 1971.\n' \
-               'https://github.com/SimonBorin/trek_bot/\n' \
-               '@blooomberg\n'
+def plot(update, context):
+    plot_msg = (
+        "You command the starship Enterprise.\n"
+        "Your mission is to seek out and destroy the Klingon fleet threatening "
+        "the United Federation of Planets before time runs out."
+    )
     context.bot.edit_message_text(chat_id=update.effective_chat.id,
                                   message_id=update.callback_query.message.message_id,
-                                  text=info_msg,
+                                  text=plot_msg,
+                                  reply_markup=menu_keyboard())
+
+
+def about(update, context):
+    context.bot.edit_message_text(chat_id=update.effective_chat.id,
+                                  message_id=update.callback_query.message.message_id,
+                                  text=ABOUT_TEXT,
                                   reply_markup=menu_keyboard())
 
 
@@ -792,7 +802,8 @@ def showhelp():
 5 - Shields
 6 - Resign
     Manual
-    Info
+    Plot
+    About
 ```
     '''
     return msg
@@ -878,7 +889,7 @@ def num_menu(update, context):
     params = parameters_db.find_one({'_id': chat_id})
     sub_params = sub_param_db.find_one({'_id': chat_id})
     input = update.callback_query.data
-    pattern = re.compile("^\d*$")
+    pattern = re.compile(r"^\d*$")
     if pattern.match(input):
         temp_num = params['num_input']
         temp_num += input
@@ -1169,7 +1180,8 @@ tst
     CallbackQueryHandler(num_backspace, pattern='backspace'),
     CallbackQueryHandler(phasers_button, pattern='phasers'),
     CallbackQueryHandler(torpedoes_button, pattern='torpedoes'),
-    CallbackQueryHandler(info, pattern='info'),
+    CallbackQueryHandler(plot, pattern=r'^(plot|info)$'),
+    CallbackQueryHandler(about, pattern=r'^about$'),
     CallbackQueryHandler(manual_menu, pattern='manual'),
     CallbackQueryHandler(back2menu, pattern='back2menu'),
     CallbackQueryHandler(galaxy_info, pattern='galaxyInfo'),


### PR DESCRIPTION
## Summary

- rename the existing story menu action to `Plot`
- add a separate `About` action
- show the automatically resolved game version, author `Simon Borin (@blooomberg)`, and the GitHub URL
- keep old `info` callbacks compatible with already-sent Telegram messages
- centralize project metadata in `game_metadata.py`
- calculate the next patch version from the latest stable SemVer tag
- automatically tag merged `master` commits
- build and publish a versioned GHCR image after the release tag is created

## Versioning

- The current release baseline is tagged `v0.1.2`.
- An untagged next commit resolves to `0.1.3`.
- A commit already carrying a stable tag reports that tag instead of incrementing again.
- `GAME_VERSION` can override repository detection for packaged deployments.
- No version number is hardcoded in the bot metadata.

## Post-merge deployment

1. A merged `master` commit receives the next stable tag.
2. The image is built from that tagged revision.
3. The same `vX.Y.Z` is passed into the image as `GAME_VERSION`.
4. The bot displays that exact tag in About.
5. The image is published as:
   - `ghcr.io/simonborin/trek_bot:vX.Y.Z`
   - `ghcr.io/simonborin/trek_bot:latest`

## Verification

- `python -m pytest` — 12 passed
- `python3 -m py_compile trek.py keyboards.py game_metadata.py scripts/next_version.py`
- `git diff --check`

## Tests

| Requirement | Evidence |
|---|---|
| Plot and About menu actions | `test_main_menu_exposes_plot_and_about_actions` |
| Plot handler registration | `test_plot_callback_handler_is_registered` |
| About handler registration | `test_about_callback_handler_is_registered` |
| Version, author, and repository metadata | `test_about_text_uses_centralized_version_author_and_repository_metadata` |
| `v0.1.2` to `0.1.3` patch calculation | `test_next_version_increments_latest_stable_v0_1_2_tag_to_0_1_3` |
| Tagged commit keeps its current version | `test_version_at_v0_1_2_tagged_head_reports_0_1_2` |
| Automatic release tags after merge | `test_release_workflow_tags_merged_master_commits_automatically` |
| Same release tag in image and About | `test_release_workflow_pushes_semver_and_latest_images_with_same_build_version`, `test_about_displays_same_v_prefixed_release_tag_from_environment` |
| Runtime image receives `GAME_VERSION` | `test_dockerfile_promotes_build_version_to_runtime_environment` |
